### PR TITLE
Highlight a grid for laying out regular beats

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -150,12 +150,16 @@ header a {
 .bar, .note {
   background-color: #888;
   border-radius: 2px;
-  border: 0;
+  border: 2px solid transparent;
   margin: 2px;
   height: 30px;
   width: 25px;
   float: left;
   outline: none;
+}
+
+.bar:nth-child(4n - 3) {
+  border: 2px solid #B6B6B6;
 }
 
 .note span {


### PR DESCRIPTION
This PR:
  - Adds a CSS rule to highlight every 4th position on the grid.
  - Ensures you can still see where the grid is even if you've lit up the entire board (by using borders)

Screenshot:

![image](https://cloud.githubusercontent.com/assets/12995/6879275/16792f78-d4ae-11e4-9b8e-496bc9cce242.png)
